### PR TITLE
Add support for type and value aliases for newly added custom type traits

### DIFF
--- a/include/opencl_type_traits
+++ b/include/opencl_type_traits
@@ -314,6 +314,8 @@ template <> struct is_image<image2d_array_t> : public true_type {};
 template <> struct is_image<image2d_depth_t> : public true_type {};
 template <> struct is_image<image2d_array_depth_t> : public true_type {};
 
+template <typename T> inline constexpr bool is_image_v = is_image<T>::value;
+
 // image_dimension
 
 template <typename T>
@@ -341,6 +343,9 @@ template <>
 struct image_dimension<image2d_array_depth_t>
     : public integral_constant<size_t, 2> {};
 
+template <typename T>
+inline constexpr size_t image_dimension_v = image_dimension<T>::value;
+
 // add address spaces
 
 template <typename T> struct add_generic { using type = __generic T; };
@@ -363,30 +368,39 @@ template <typename T> struct has_address_space<__local T> : public true_type {};
 template <typename T>
 struct has_address_space<__constant T> : public true_type {};
 
+template <typename T>
+inline constexpr bool has_address_space_v = has_address_space<T>::value;
+
 // is_generic
 
 template <typename T> struct is_generic : public false_type {};
 template <typename T> struct is_generic<__generic T> : public true_type {};
+template <typename T> inline constexpr bool is_generic_v = is_generic<T>::value;
 
 // is_global
 
 template <typename T> struct is_global : public false_type {};
 template <typename T> struct is_global<__global T> : public true_type {};
+template <typename T> inline constexpr bool is_global_v = is_global<T>::value;
 
 // is_private
 
 template <typename T> struct is_private : public false_type {};
 template <typename T> struct is_private<__private T> : public true_type {};
+template <typename T> inline constexpr bool is_private_v = is_private<T>::value;
 
 // is_local
 
 template <typename T> struct is_local : public false_type {};
 template <typename T> struct is_local<__local T> : public true_type {};
+template <typename T> inline constexpr bool is_local_v = is_local<T>::value;
 
 // is_constant
 
 template <typename T> struct is_constant : public false_type {};
 template <typename T> struct is_constant<__constant T> : public true_type {};
+template <typename T>
+inline constexpr bool is_constant_v = is_constant<T>::value;
 
 // remove_address_space
 
@@ -407,6 +421,9 @@ template <typename T> struct remove_address_space<__local T> {
 template <typename T> struct remove_address_space<__constant T> {
   using type = T;
 };
+
+template <typename T>
+using remove_address_space_t = typename remove_address_space<T>::type;
 
 } // namespace std
 

--- a/test/address_space_traits.clcpp
+++ b/test/address_space_traits.clcpp
@@ -2,15 +2,15 @@
 
 void test_address_space_traits() {
   static_assert(
-      std::is_same<std::remove_address_space<__generic int>::type, int>::value);
+      std::is_same<std::remove_address_space_t<__generic int>, int>::value);
   static_assert(std::is_same<std::remove_address_space<__global char>::type,
                              char>::value);
-  static_assert(std::is_same<std::remove_address_space<__private ulong>::type,
-                             ulong>::value);
+  static_assert(
+      std::is_same<std::remove_address_space_t<__private ulong>, ulong>::value);
   static_assert(std::is_same<std::remove_address_space<__local short>::type,
                              short>::value);
-  static_assert(std::is_same<std::remove_address_space<__constant int3>::type,
-                             int3>::value);
+  static_assert(
+      std::is_same<std::remove_address_space_t<__constant int3>, int3>::value);
 
   static_assert(
       std::is_same<std::add_generic<char>::type, __generic char>::value);
@@ -22,21 +22,21 @@ void test_address_space_traits() {
   static_assert(
       std::is_same<std::add_constant<char>::type, __constant char>::value);
 
-  static_assert(std::is_generic<__generic char>::value);
+  static_assert(std::is_generic_v<__generic char>);
   static_assert(!std::is_generic<char>::value);
   static_assert(std::is_global<__global int>::value);
-  static_assert(!std::is_global<int>::value);
-  static_assert(std::is_private<__private float16>::value);
+  static_assert(!std::is_global_v<int>);
+  static_assert(std::is_private_v<__private float16>);
   static_assert(!std::is_private<__global char3>::value);
   static_assert(std::is_local<__local double>::value);
-  static_assert(!std::is_local<short>::value);
-  static_assert(std::is_constant<__constant int>::value);
+  static_assert(!std::is_local_v<short>);
+  static_assert(std::is_constant_v<__constant int>);
   static_assert(!std::is_constant<__generic char>::value);
 
-  static_assert(std::has_address_space<__generic int>::value);
+  static_assert(std::has_address_space_v<__generic int>);
   static_assert(std::has_address_space<__global char>::value);
-  static_assert(std::has_address_space<__private float>::value);
+  static_assert(std::has_address_space_v<__private float>);
   static_assert(std::has_address_space<__local short2>::value);
-  static_assert(std::has_address_space<__constant long>::value);
+  static_assert(std::has_address_space_v<__constant long>);
   static_assert(!std::has_address_space<float4>::value);
 }

--- a/test/image_type_traits.clcpp
+++ b/test/image_type_traits.clcpp
@@ -2,24 +2,24 @@
 
 void test_misc_type_traits() {
   static_assert(std::is_image<image1d_t>::value);
-  static_assert(std::is_image<image2d_t>::value);
+  static_assert(std::is_image_v<image2d_t>);
   static_assert(std::is_image<image3d_t>::value);
-  static_assert(std::is_image<image1d_array_t>::value);
+  static_assert(std::is_image_v<image1d_array_t>);
   static_assert(std::is_image<image1d_buffer_t>::value);
-  static_assert(std::is_image<image2d_array_t>::value);
+  static_assert(std::is_image_v<image2d_array_t>);
   static_assert(std::is_image<image2d_depth_t>::value);
-  static_assert(std::is_image<image2d_array_depth_t>::value);
+  static_assert(std::is_image_v<image2d_array_depth_t>);
   static_assert(!std::is_image<sampler_t>::value);
-  static_assert(!std::is_image<uint2>::value);
+  static_assert(!std::is_image_v<uint2>);
 
   static_assert(std::image_dimension<image1d_t>::value == 1);
-  static_assert(std::image_dimension<image2d_t>::value == 2);
+  static_assert(std::image_dimension_v<image2d_t> == 2);
   static_assert(std::image_dimension<image3d_t>::value == 3);
-  static_assert(std::image_dimension<image1d_array_t>::value == 1);
+  static_assert(std::image_dimension_v<image1d_array_t> == 1);
   static_assert(std::image_dimension<image1d_buffer_t>::value == 1);
-  static_assert(std::image_dimension<image2d_array_t>::value == 2);
+  static_assert(std::image_dimension_v<image2d_array_t> == 2);
   static_assert(std::image_dimension<image2d_depth_t>::value == 2);
-  static_assert(std::image_dimension<image2d_array_depth_t>::value == 2);
+  static_assert(std::image_dimension_v<image2d_array_depth_t> == 2);
   static_assert(std::image_dimension<int>::value == 0);
-  static_assert(std::image_dimension<ndrange_t>::value == 0);
+  static_assert(std::image_dimension_v<ndrange_t> == 0);
 }


### PR DESCRIPTION
Add support for `<type_trait>_v` and `<type_trait>_t` aliases to directly access the type trait type and values for the newly added custom type traits.