### PR TITLE
Add CMake integration for automatic building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@
 *.out
 *.app
 
-#CMake
+# CMake
 CMakeLists.txt.user
 CMakeCache.txt
 CMakeFiles
@@ -44,3 +44,7 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+
+# Build
+build
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 project(libclcxx)
 
 set(CUSTOM_COMMAND_USED OFF CACHE BOOL "A variable to see if a custom configuration command is called")
-set(LLVM_TARGETS_TO_BUILD="X86" CACHE STRING "This is the default target build system type")
+set(LLVM_TARGETS_TO_BUILD "X86" CACHE STRING "This is the default target build system type" FORCE)
 set(CMAKE_BUILD_TYPE "Debug")
 
 # Default clang build; uses the command "clang" to call and use clang to compile libcxx and tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ if (NOT CUSTOM_COMMAND_USED)
     )
   add_custom_target(
     test
-    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${CMAKE_BINARY_DIR}/llvm-project/llvm/include/c++/v1/ CLANG_PATH=${CMAKE_BINARY_DIR}/llvm-project/llvm/bin/clang-13
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${CMAKE_BINARY_DIR}/llvm-project/llvm/include/c++/v1/ CLANG_PATH=${CMAKE_BINARY_DIR}/llvm-project/llvm/bin/clang-14
     )
   add_custom_target(
     clean_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,15 @@ if ((DEFAULT_CLANG) AND (NOT DEFAULT_LIBCXX) AND (CLANG_PATH STREQUAL "") AND (L
     COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${CMAKE_BINARY_DIR}/llvm-project/llvm/include/c++/v1/ EXTRA_ARGS=${EXTRA_CLANG_12_FLAGS}
     )
   add_custom_target(
+    # This target cleans the compiled test object files from the test source directory
     clean_test
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
+    )
+  add_custom_target(
+    # This target cleans all build files, compiled test object files and (if relevant) copied opencl_ include files from your default or provided libcxx installation
+    clean_all
+    COMMAND cd ${CMAKE_BINARY_DIR} && rm -r *
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean 
     )
 endif()
 
@@ -89,6 +96,11 @@ if ((LIBCXX_PATH STREQUAL "") AND (NOT CLANG_PATH STREQUAL "") AND (NOT DEFAULT_
     clean_test
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
     )
+  add_custom_target(
+    clean_all
+    COMMAND cd ${CMAKE_BINARY_DIR} && rm -r *
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean 
+    )
 endif()
 
 # Default libcxx build; uses default installation of libcxx in system
@@ -110,15 +122,22 @@ if ((DEFAULT_LIBCXX) AND (NOT DEFAULT_CLANG) AND (CLANG_PATH STREQUAL "") AND (L
     )
   add_custom_target(
     test
-    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${CMAKE_INSTALL_PREFIX}/include/c++/v1/ CLANG_PATH=${CMAKE_BINARY_DIR}/llvm-project/llvm/bin/clang-14
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${CMAKE_INSTALL_PREFIX}/include/c++/v1/ CLANG_PATH=${CMAKE_BINARY_DIR}/llvm-project/llvm/bin/clang
     )
   add_custom_target(
     clean_test
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
     )
   add_custom_target(
-    remove_libclcxx
+    # This target removes the opencl_<> include files from your libcxx installation
+    clean_libclcxx
     command cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_*
+    )
+  add_custom_target(
+    clean_all
+    COMMAND cd ${CMAKE_BINARY_DIR}/ && rm -r *
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
+    COMMAND cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_* 
     )
 endif()
 
@@ -141,15 +160,21 @@ if ((CLANG_PATH STREQUAL "") AND (NOT LIBCXX_PATH STREQUAL "") AND (NOT DEFAULT_
     )
   add_custom_target(
     test
-    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${LIBCXX_PATH}/include/c++/v1/ CLANG_PATH=${CMAKE_BINARY_DIR}/llvm-project/llvm/bin/clang-14
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${LIBCXX_PATH}/include/c++/v1/ CLANG_PATH=${CMAKE_BINARY_DIR}/llvm-project/llvm/bin/clang
     )
   add_custom_target(
     clean_test
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
     )
   add_custom_target(
-    remove_libclcxx
+    clean_libclcxx
     command cd ${LIBCXX_PATH}/include/c++/v1/ && rm opencl_*
+    )
+  add_custom_target(
+    clean_all
+    COMMAND cd ${CMAKE_BINARY_DIR}/ && rm -r *
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
+    COMMAND cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_* 
     )
 endif()
 
@@ -183,8 +208,13 @@ if ((DEFAULT_CLANG) AND (DEFAULT_LIBCXX) AND (CLANG_PATH STREQUAL "") AND (LIBCX
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
     )
   add_custom_target(
-    remove_libclcxx
+    clean_libclcxx
     command cd ${LIBCXX_PATH}/include/c++/v1/ && rm opencl_*
+    )
+  add_custom_target(
+    clean_all
+    COMMAND cd ${CMAKE_BINARY_DIR}/ && rm -r *
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean ; cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_* 
     )
 endif()
 
@@ -218,8 +248,14 @@ if ((NOT LIBCXX_PATH STREQUAL "") AND (NOT CLANG_PATH STREQUAL "") AND (NOT DEFA
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
     )
   add_custom_target(
-    remove_libclcxx
+    clean_libclcxx
     command cd ${LIBCXX_PATH}/include/c++/v1/ && rm opencl_*
+    )
+  add_custom_target(
+    clean_all
+    COMMAND cd ${CMAKE_BINARY_DIR}/ && rm -r *
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
+    COMMAND cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_* 
     )
 endif()
 
@@ -253,8 +289,14 @@ if ((DEFAULT_LIBCXX) AND (NOT CLANG_PATH STREQUAL "") AND (NOT DEFAULT_CLANG) AN
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
     )
   add_custom_target(
-    remove_libclcxx
+    clean_libclcxx
     command cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_*
+    )
+  add_custom_target(
+    clean_all
+    COMMAND cd ${CMAKE_BINARY_DIR}/ && rm -r * 
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
+    COMMAND cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_* 
     )
 endif()
 
@@ -288,8 +330,14 @@ if ((NOT LIBCXX_PATH STREQUAL "") AND (DEFAULT_CLANG) AND (NOT DEFAULT_LIBCXX) A
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
     )
   add_custom_target(
-    remove_libclcxx
+    clean_libclcxx
     command cd ${LIBCXX_PATH}/include/c++/v1/ && rm opencl_*
+    )
+  add_custom_target(
+    clean_all
+    COMMAND cd ${CMAKE_BINARY_DIR}/ && rm -r * 
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean 
+    COMMAND cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_* 
     )
 endif()
 
@@ -312,11 +360,16 @@ if ((NOT DEFAULT_CLANG) AND (NOT DEFAULT_LIBCXX) AND (CLANG_PATH STREQUAL "") AN
     )
   add_custom_target(
     test
-    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${CMAKE_BINARY_DIR}/llvm-project/llvm/include/c++/v1/ CLANG_PATH=${CMAKE_BINARY_DIR}/llvm-project/llvm/bin/clang-14
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${CMAKE_BINARY_DIR}/llvm-project/llvm/include/c++/v1/ CLANG_PATH=${CMAKE_BINARY_DIR}/llvm-project/llvm/bin/clang
     )
   add_custom_target(
     clean_test
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
+    )
+  add_custom_target(
+    clean_all
+    COMMAND cd ${CMAKE_BINARY_DIR}/ && rm -r *
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean 
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,183 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 3.20.5)
+
+option(DEFAULT_CLANG "Use installation of clang in your system" OFF)
+set(CLANG_PATH "" CACHE STRING "path/to/clang")
+option(DEFAULT_LIBCXX "Use installation of libcxx in your system" OFF)
+set(LIBCXX_PATH "" CACHE STRING "path/to/libcxx")
+
+if (DEFAULT_CLANG)
+  set(CMAKE_C_COMPILER "clang")
+  set(CMAKE_CXX_COMPILER "clang")
+endif()
+
+if (NOT CLANG_PATH STREQUAL "")
+  set(CMAKE_C_COMPILER "${CLANG_PATH}")
+  set(CMAKE_CXX_COMPILER "${CLANG_PATH}")
+endif()
+
+project(libclcxx)
+
+set(CUSTOM_COMMAND_USED OFF CACHE BOOL "A variable to see if a custom configuration command is called")
+set(LLVM_TARGETS_TO_BUILD="X86" CACHE STRING "This is the default target build system type")
+set(CMAKE_BUILD_TYPE "Debug")
+
+# Default clang build; uses the command "clang" to call and use clang to compile libcxx and tests
+# Note this option only works if the clang executable or symlink is called "clang" and not "clang-12" or "clang-13"
+# In those cases it's recommended to use the CLANG_PATH option
+if (DEFAULT_CLANG)
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
+    message(FATAL_ERROR "Libclcxx does not support clang versions older than clang-12")
+  endif()
+  set(CUSTOM_COMMAND_USED ON)
+  set(LLVM_ENABLE_PROJECTS "libcxx;libcxxabi" CACHE STRING "Enable projects libcxx and libcxxabi" FORCE)
+  set(LLVM_ENABLE_LIBCXX ON CACHE BOOL "This is required to allow libstdc++ tests to pass" FORCE)
+  add_subdirectory(llvm-project/llvm)
+  message(STATUS "Using default clang installation in system")
+  message(STATUS "Configuring tests")
+  if (CMAKE_CXX_COMPILER_VERSION EQUAL 12)
+    set(EXTRA_CLANG_12_FLAGS "-x cl -Xclang -finclude-default-header -Xclang -fdeclare-opencl-builtins -cl-std=clc++")
+  endif()
+  add_custom_target(
+    tools
+    DEPENDS cxx
+    )
+  add_custom_command(
+    TARGET tools
+    POST_BUILD
+    COMMAND cp ${CMAKE_SOURCE_DIR}/include/* ${CMAKE_BINARY_DIR}/llvm-project/llvm/include/c++/v1/
+    COMMENT "Copying libclcxx include files into build include dir"
+    )
+  add_custom_target(
+    test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${CMAKE_BINARY_DIR}/llvm-project/llvm/include/c++/v1/ EXTRA_ARGS=${EXTRA_CLANG_12_FLAGS}
+    )
+  add_custom_target(
+    clean_test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
+    )
+endif()
+
+# Clang path given build; Builds libcxx and compiles tests using the clang executable path provided
+if (NOT CLANG_PATH STREQUAL "")
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
+    message(FATAL_ERROR "Libclcxx does not support clang versions older than clang-12")
+  endif()
+  set(CUSTOM_COMMAND_USED ON)
+  set(LLVM_ENABLE_PROJECTS "libcxx;libcxxabi" CACHE STRING "Enable projects libcxx and libcxxabi" FORCE)
+  set(LLVM_ENABLE_LIBCXX ON CACHE BOOL "This is required to allow libstdc++ tests to pass" FORCE)
+  add_subdirectory(llvm-project/llvm)
+  message(STATUS "Using path to clang executable provided")
+  message(STATUS "Configuring tests")
+  if (CMAKE_CXX_COMPILER_VERSION EQUAL 12)
+    set(EXTRA_CLANG_12_FLAGS "-x cl -Xclang -finclude-default-header -Xclang -fdeclare-opencl-builtins -cl-std=clc++")
+  endif()
+  add_custom_target(
+    tools
+    DEPENDS cxx
+    )
+  add_custom_command(
+    TARGET tools
+    POST_BUILD
+    COMMAND cp ${CMAKE_SOURCE_DIR}/include/* ${CMAKE_BINARY_DIR}/llvm-project/llvm/include/c++/v1/
+    COMMENT "Copying libclcxx include files into build include dir"
+    )
+  add_custom_target(
+    test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${CMAKE_BINARY_DIR}/llvm-project/llvm/include/c++/v1/ CLANG_PATH=${CLANG_PATH} EXTRA_ARGS=${EXTRA_CLANG_12_FLAGS}
+    )
+  add_custom_target(
+    clean_test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
+    )
+endif()
+
+# Default libcxx build; uses default installation of libcxx in system
+if (DEFAULT_LIBCXX)
+  set(CUSTOM_COMMAND_USED ON)
+  set(LLVM_ENABLE_PROJECTS "clang" CACHE STRING "Enable project clang")
+  add_subdirectory(llvm-project/llvm)
+  message(STATUS "Using default libcxx installation in system")
+  message(STATUS "Configuring tests")
+  add_custom_target(
+    tools
+    DEPENDS clang
+    )
+  add_custom_command(
+    TARGET tools
+    POST_BUILD
+    COMMAND cp ${CMAKE_SOURCE_DIR}/include/* ${CMAKE_INSTALL_PREFIX}/include/c++/v1/
+    COMMENT "Copying libclcxx include files into build include dir"
+    )
+  add_custom_target(
+    test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${CMAKE_INSTALL_PREFIX}/include/c++/v1/ CLANG_PATH=${CMAKE_BINARY_DIR}/llvm-project/llvm/bin/clang-13
+    )
+  add_custom_target(
+    clean_test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
+    )
+  add_custom_target(
+    remove_libclcxx
+    command cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_*
+    )
+endif()
+
+# Libcxx path given build; builds clang using default system compiler and compiles tests using built clang and libcxx library path provided
+if (NOT LIBCXX_PATH STREQUAL "")
+  set(CUSTOM_COMMAND_USED ON)
+  #set(LLVM_ENABLE_LIBCXX ON CACHE BOOL "This is required to allow libstdc++ tests to pass" FORCE)
+  set(LLVM_ENABLE_PROJECTS "clang" CACHE STRING "Enable project clang")
+  add_subdirectory(llvm-project/llvm)
+  message(STATUS "Using path to libcxx provided")
+  message(STATUS "Configuring tests")
+  add_custom_target(
+    tools
+    DEPENDS clang
+    )
+  add_custom_command(
+    TARGET tools
+    POST_BUILD
+    COMMAND cp ${CMAKE_SOURCE_DIR}/include/* ${LIBCXX_PATH}/include/c++/v1/
+    COMMENT "Copying libclcxx include files into build include dir"
+    )
+  add_custom_target(
+    test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${LIBCXX_PATH}/include/c++/v1/ CLANG_PATH=${CMAKE_BINARY_DIR}/llvm-project/llvm/bin/clang-13
+    )
+  add_custom_target(
+    clean_test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
+    )
+  add_custom_target(
+    remove_libclcxx
+    command cd ${LIBCXX_PATH}/include/c++/v1/ && rm opencl_*
+    )
+endif()
+
+# Default build; builds clang and libcxx and uses the newly built clang to compile tests
+if (NOT CUSTOM_COMMAND_USED)
+  set(LLVM_ENABLE_PROJECTS "clang;libcxx;libcxxabi" CACHE STRING "Enable projects clang, libcxx and libcxxabi" FORCE)
+  set(LLVM_ENABLE_LIBCXX ON CACHE BOOL "This is required to allow libstdc++ tests to pass" FORCE)
+  add_subdirectory(llvm-project/llvm)
+  message(STATUS "Configuring builds of clang, libcxx and libcxxabi into build folder")
+  message(STATUS "Configuring tests")
+  add_custom_target(
+    tools
+    DEPENDS clang cxx
+    )
+  add_custom_command(
+    TARGET tools
+    POST_BUILD
+    COMMAND cp ${CMAKE_SOURCE_DIR}/include/* ${CMAKE_BINARY_DIR}/llvm-project/llvm/include/c++/v1/
+    COMMENT "Copying libclcxx include files into build include dir"
+    )
+  add_custom_target(
+    test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${CMAKE_BINARY_DIR}/llvm-project/llvm/include/c++/v1/ CLANG_PATH=${CMAKE_BINARY_DIR}/llvm-project/llvm/bin/clang-13
+    )
+  add_custom_target(
+    clean_test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
+    )
+endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ if ((DEFAULT_CLANG) AND (NOT DEFAULT_LIBCXX) AND (CLANG_PATH STREQUAL "") AND (L
     )
   add_custom_target(
     # This target cleans all build files, compiled test object files and (if relevant) copied opencl_ include files from your default or provided libcxx installation
-    clean_all
+    clean
     COMMAND cd ${CMAKE_BINARY_DIR} && rm -r *
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean 
     )
@@ -97,7 +97,7 @@ if ((LIBCXX_PATH STREQUAL "") AND (NOT CLANG_PATH STREQUAL "") AND (NOT DEFAULT_
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
     )
   add_custom_target(
-    clean_all
+    clean
     COMMAND cd ${CMAKE_BINARY_DIR} && rm -r *
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean 
     )
@@ -134,7 +134,7 @@ if ((DEFAULT_LIBCXX) AND (NOT DEFAULT_CLANG) AND (CLANG_PATH STREQUAL "") AND (L
     command cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_*
     )
   add_custom_target(
-    clean_all
+    clean
     COMMAND cd ${CMAKE_BINARY_DIR}/ && rm -r *
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
     COMMAND cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_* 
@@ -171,7 +171,7 @@ if ((CLANG_PATH STREQUAL "") AND (NOT LIBCXX_PATH STREQUAL "") AND (NOT DEFAULT_
     command cd ${LIBCXX_PATH}/include/c++/v1/ && rm opencl_*
     )
   add_custom_target(
-    clean_all
+    clean
     COMMAND cd ${CMAKE_BINARY_DIR}/ && rm -r *
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
     COMMAND cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_* 
@@ -212,7 +212,7 @@ if ((DEFAULT_CLANG) AND (DEFAULT_LIBCXX) AND (CLANG_PATH STREQUAL "") AND (LIBCX
     command cd ${LIBCXX_PATH}/include/c++/v1/ && rm opencl_*
     )
   add_custom_target(
-    clean_all
+    clean
     COMMAND cd ${CMAKE_BINARY_DIR}/ && rm -r *
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean ; cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_* 
     )
@@ -252,7 +252,7 @@ if ((NOT LIBCXX_PATH STREQUAL "") AND (NOT CLANG_PATH STREQUAL "") AND (NOT DEFA
     command cd ${LIBCXX_PATH}/include/c++/v1/ && rm opencl_*
     )
   add_custom_target(
-    clean_all
+    clean
     COMMAND cd ${CMAKE_BINARY_DIR}/ && rm -r *
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
     COMMAND cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_* 
@@ -293,7 +293,7 @@ if ((DEFAULT_LIBCXX) AND (NOT CLANG_PATH STREQUAL "") AND (NOT DEFAULT_CLANG) AN
     command cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_*
     )
   add_custom_target(
-    clean_all
+    clean
     COMMAND cd ${CMAKE_BINARY_DIR}/ && rm -r * 
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
     COMMAND cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_* 
@@ -334,7 +334,7 @@ if ((NOT LIBCXX_PATH STREQUAL "") AND (DEFAULT_CLANG) AND (NOT DEFAULT_LIBCXX) A
     command cd ${LIBCXX_PATH}/include/c++/v1/ && rm opencl_*
     )
   add_custom_target(
-    clean_all
+    clean
     COMMAND cd ${CMAKE_BINARY_DIR}/ && rm -r * 
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean 
     COMMAND cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_* 
@@ -367,7 +367,7 @@ if ((NOT DEFAULT_CLANG) AND (NOT DEFAULT_LIBCXX) AND (CLANG_PATH STREQUAL "") AN
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
     )
   add_custom_target(
-    clean_all
+    clean
     COMMAND cd ${CMAKE_BINARY_DIR}/ && rm -r *
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean 
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CMAKE_BUILD_TYPE "Debug")
 # Default clang build; uses the command "clang" to call and use clang to compile libcxx and tests
 # Note this option only works if the clang executable or symlink is called "clang" and not "clang-12" or "clang-13"
 # In those cases it's recommended to use the CLANG_PATH option
-if (DEFAULT_CLANG AND NOT DEFAULT LIBCXX)
+if ((DEFAULT_CLANG) AND (NOT DEFAULT_LIBCXX) AND (CLANG_PATH STREQUAL "") AND (LIBCXX_PATH STREQUAL ""))
   if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
     message(FATAL_ERROR "Libclcxx does not support clang versions older than clang-12")
   endif()
@@ -58,7 +58,7 @@ if (DEFAULT_CLANG AND NOT DEFAULT LIBCXX)
 endif()
 
 # Clang path given build; Builds libcxx and compiles tests using the clang executable path provided
-if (LIBCXX_PATH STREQUAL "" AND NOT CLANG_PATH STREQUAL "")
+if ((LIBCXX_PATH STREQUAL "") AND (NOT CLANG_PATH STREQUAL "") AND (NOT DEFAULT_CLANG) AND (NOT DEFAULT_LIBCXX))
   if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
     message(FATAL_ERROR "Libclcxx does not support clang versions older than clang-12")
   endif()
@@ -92,7 +92,7 @@ if (LIBCXX_PATH STREQUAL "" AND NOT CLANG_PATH STREQUAL "")
 endif()
 
 # Default libcxx build; uses default installation of libcxx in system
-if (DEFAULT_LIBCXX AND NOT DEFAULT_CLANG)
+if ((DEFAULT_LIBCXX) AND (NOT DEFAULT_CLANG) AND (CLANG_PATH STREQUAL "") AND (LIBCXX_PATH STREQUAL ""))
   set(CUSTOM_COMMAND_USED ON)
   set(LLVM_ENABLE_PROJECTS "clang" CACHE STRING "Enable project clang")
   add_subdirectory(llvm-project/llvm)
@@ -110,7 +110,7 @@ if (DEFAULT_LIBCXX AND NOT DEFAULT_CLANG)
     )
   add_custom_target(
     test
-    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${CMAKE_INSTALL_PREFIX}/include/c++/v1/ CLANG_PATH=${CMAKE_BINARY_DIR}/llvm-project/llvm/bin/clang-13
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${CMAKE_INSTALL_PREFIX}/include/c++/v1/ CLANG_PATH=${CMAKE_BINARY_DIR}/llvm-project/llvm/bin/clang-14
     )
   add_custom_target(
     clean_test
@@ -123,7 +123,7 @@ if (DEFAULT_LIBCXX AND NOT DEFAULT_CLANG)
 endif()
 
 # Libcxx path given build; builds clang using default system compiler and compiles tests using built clang and libcxx library path provided
-if (CLANG_PATH STREQUAL "" AND NOT LIBCXX_PATH STREQUAL "")
+if ((CLANG_PATH STREQUAL "") AND (NOT LIBCXX_PATH STREQUAL "") AND (NOT DEFAULT_CLANG) AND (NOT DEFAULT_CXX))
   set(CUSTOM_COMMAND_USED ON)
   set(LLVM_ENABLE_PROJECTS "clang" CACHE STRING "Enable project clang")
   add_subdirectory(llvm-project/llvm)
@@ -141,7 +141,7 @@ if (CLANG_PATH STREQUAL "" AND NOT LIBCXX_PATH STREQUAL "")
     )
   add_custom_target(
     test
-    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${LIBCXX_PATH}/include/c++/v1/ CLANG_PATH=${CMAKE_BINARY_DIR}/llvm-project/llvm/bin/clang-13
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${LIBCXX_PATH}/include/c++/v1/ CLANG_PATH=${CMAKE_BINARY_DIR}/llvm-project/llvm/bin/clang-14
     )
   add_custom_target(
     clean_test
@@ -154,7 +154,7 @@ if (CLANG_PATH STREQUAL "" AND NOT LIBCXX_PATH STREQUAL "")
 endif()
 
 # Default clang and default libcxx build; uses default clang and libcxx installation paths to compile tests
-if (DEFAULT_CLANG AND DEFAULT_CXX)
+if ((DEFAULT_CLANG) AND (DEFAULT_LIBCXX) AND (CLANG_PATH STREQUAL "") AND (LIBCXX_PATH STREQUAL ""))
   if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
     message(FATAL_ERROR "Libclcxx does not support clang versions older than clang-12")
   endif()
@@ -171,12 +171,12 @@ if (DEFAULT_CLANG AND DEFAULT_CXX)
   add_custom_command(
     TARGET tools
     POST_BUILD
-    COMMAND cp ${CMAKE_SOURCE_DIR}/include/* ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ EXTRA_ARGS=${EXTRA_CLANG_12_FLAGS}
+    COMMAND cp ${CMAKE_SOURCE_DIR}/include/* ${CMAKE_INSTALL_PREFIX}/include/c++/v1/
     COMMENT "Copying libclcxx include files into build include dir"
     )
   add_custom_target(
     test
-    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${CMAKE_INSTALL_PREFIX}/include/c++/v1/
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${CMAKE_INSTALL_PREFIX}/include/c++/v1/ EXTRA_ARGS=${EXTRA_CLANG_12_FLAGS}
     )
   add_custom_target(
     clean_test
@@ -189,7 +189,7 @@ if (DEFAULT_CLANG AND DEFAULT_CXX)
 endif()
 
 # Clang and libcxx path given build; uses provided clang and libcxx installation paths to compile tests
-if (NOT LIBCXX_PATH STREQUAL "" AND NOT CLANG_PATH STREQUAL "")
+if ((NOT LIBCXX_PATH STREQUAL "") AND (NOT CLANG_PATH STREQUAL "") AND (NOT DEFAULT_CLANG) AND (NOT DEFAULT_LIBCXX))
   if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
     message(FATAL_ERROR "Libclcxx does not support clang versions older than clang-12")
   endif()
@@ -223,8 +223,78 @@ if (NOT LIBCXX_PATH STREQUAL "" AND NOT CLANG_PATH STREQUAL "")
     )
 endif()
 
+# Clang path given and default libcxx build; uses provided clang installation path and default libcxx installation to compile tests
+if ((DEFAULT_LIBCXX) AND (NOT CLANG_PATH STREQUAL "") AND (NOT DEFAULT_CLANG) AND (LIBCXX_PATH STREQUAL ""))
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
+    message(FATAL_ERROR "Libclcxx does not support clang versions older than clang-12")
+  endif()
+  set(CUSTOM_COMMAND_USED ON)
+  message(STATUS "Using path to clang provided")
+  message(STATUS "Using default libcxx installation")
+  message(STATUS "Configuring tests")
+  if (CMAKE_CXX_COMPILER_VERSION EQUAL 12)
+    set(EXTRA_CLANG_12_FLAGS "-x cl -Xclang -finclude-default-header -Xclang -fdeclare-opencl-builtins -cl-std=clc++")
+  endif()
+  add_custom_target(
+    tools
+    )
+  add_custom_command(
+    TARGET tools
+    POST_BUILD
+    COMMAND cp ${CMAKE_SOURCE_DIR}/include/* ${CMAKE_INSTALL_PREFIX}/include/c++/v1/
+    COMMENT "Copying libclcxx include files into build include dir"
+    )
+  add_custom_target(
+    test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${CMAKE_INSTALL_PREFIX}/include/c++/v1/ CLANG_PATH=${CLANG_PATH} EXTRA_ARGS=${EXTRA_CLANG_12_FLAGS}
+    )
+  add_custom_target(
+    clean_test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
+    )
+  add_custom_target(
+    remove_libclcxx
+    command cd ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ && rm opencl_*
+    )
+endif()
+
+# Default clang installation and libcxx path given build; uses default clang installation  and provided libcxx installation path to compile tests
+if ((NOT LIBCXX_PATH STREQUAL "") AND (DEFAULT_CLANG) AND (NOT DEFAULT_LIBCXX) AND (CLANG_PATH STREQUAL ""))
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
+    message(FATAL_ERROR "Libclcxx does not support clang versions older than clang-12")
+  endif()
+  set(CUSTOM_COMMAND_USED ON)
+  message(STATUS "Using path to clang provided")
+  message(STATUS "Using path to libcxx provided")
+  message(STATUS "Configuring tests")
+  if (CMAKE_CXX_COMPILER_VERSION EQUAL 12)
+    set(EXTRA_CLANG_12_FLAGS "-x cl -Xclang -finclude-default-header -Xclang -fdeclare-opencl-builtins -cl-std=clc++")
+  endif()
+  add_custom_target(
+    tools
+    )
+  add_custom_command(
+    TARGET tools
+    POST_BUILD
+    COMMAND cp ${CMAKE_SOURCE_DIR}/include/* ${LIBCXX_PATH}/include/c++/v1/
+    COMMENT "Copying libclcxx include files into build include dir"
+    )
+  add_custom_target(
+    test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${LIBCXX_PATH}/include/c++/v1/ EXTRA_ARGS=${EXTRA_CLANG_12_FLAGS}
+    )
+  add_custom_target(
+    clean_test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
+    )
+  add_custom_target(
+    remove_libclcxx
+    command cd ${LIBCXX_PATH}/include/c++/v1/ && rm opencl_*
+    )
+endif()
+
 # Default build; builds clang and libcxx and uses the newly built clang to compile tests
-if (NOT CUSTOM_COMMAND_USED)
+if ((NOT DEFAULT_CLANG) AND (NOT DEFAULT_LIBCXX) AND (CLANG_PATH STREQUAL "") AND (LIBCXX_PATH STREQUAL ""))
   set(LLVM_ENABLE_PROJECTS "clang;libcxx;libcxxabi" CACHE STRING "Enable projects clang, libcxx and libcxxabi" FORCE)
   set(LLVM_ENABLE_LIBCXX ON CACHE BOOL "This is required to allow libstdc++ tests to pass" FORCE)
   add_subdirectory(llvm-project/llvm)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CMAKE_BUILD_TYPE "Debug")
 # Default clang build; uses the command "clang" to call and use clang to compile libcxx and tests
 # Note this option only works if the clang executable or symlink is called "clang" and not "clang-12" or "clang-13"
 # In those cases it's recommended to use the CLANG_PATH option
-if (DEFAULT_CLANG)
+if (DEFAULT_CLANG AND NOT DEFAULT LIBCXX)
   if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
     message(FATAL_ERROR "Libclcxx does not support clang versions older than clang-12")
   endif()
@@ -58,7 +58,7 @@ if (DEFAULT_CLANG)
 endif()
 
 # Clang path given build; Builds libcxx and compiles tests using the clang executable path provided
-if (NOT CLANG_PATH STREQUAL "")
+if (LIBCXX_PATH STREQUAL "" AND NOT CLANG_PATH STREQUAL "")
   if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
     message(FATAL_ERROR "Libclcxx does not support clang versions older than clang-12")
   endif()
@@ -92,7 +92,7 @@ if (NOT CLANG_PATH STREQUAL "")
 endif()
 
 # Default libcxx build; uses default installation of libcxx in system
-if (DEFAULT_LIBCXX)
+if (DEFAULT_LIBCXX AND NOT DEFAULT_CLANG)
   set(CUSTOM_COMMAND_USED ON)
   set(LLVM_ENABLE_PROJECTS "clang" CACHE STRING "Enable project clang")
   add_subdirectory(llvm-project/llvm)
@@ -123,9 +123,8 @@ if (DEFAULT_LIBCXX)
 endif()
 
 # Libcxx path given build; builds clang using default system compiler and compiles tests using built clang and libcxx library path provided
-if (NOT LIBCXX_PATH STREQUAL "")
+if (CLANG_PATH STREQUAL "" AND NOT LIBCXX_PATH STREQUAL "")
   set(CUSTOM_COMMAND_USED ON)
-  #set(LLVM_ENABLE_LIBCXX ON CACHE BOOL "This is required to allow libstdc++ tests to pass" FORCE)
   set(LLVM_ENABLE_PROJECTS "clang" CACHE STRING "Enable project clang")
   add_subdirectory(llvm-project/llvm)
   message(STATUS "Using path to libcxx provided")
@@ -143,6 +142,76 @@ if (NOT LIBCXX_PATH STREQUAL "")
   add_custom_target(
     test
     COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${LIBCXX_PATH}/include/c++/v1/ CLANG_PATH=${CMAKE_BINARY_DIR}/llvm-project/llvm/bin/clang-13
+    )
+  add_custom_target(
+    clean_test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
+    )
+  add_custom_target(
+    remove_libclcxx
+    command cd ${LIBCXX_PATH}/include/c++/v1/ && rm opencl_*
+    )
+endif()
+
+# Default clang and default libcxx build; uses default clang and libcxx installation paths to compile tests
+if (DEFAULT_CLANG AND DEFAULT_CXX)
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
+    message(FATAL_ERROR "Libclcxx does not support clang versions older than clang-12")
+  endif()
+  set(CUSTOM_COMMAND_USED ON)
+  message(STATUS "Using default installation of clang")
+  message(STATUS "Using default installation of libcxx")
+  message(STATUS "Configuring tests")
+  if (CMAKE_CXX_COMPILER_VERSION EQUAL 12)
+    set(EXTRA_CLANG_12_FLAGS "-x cl -Xclang -finclude-default-header -Xclang -fdeclare-opencl-builtins -cl-std=clc++")
+  endif()
+  add_custom_target(
+    tools
+    )
+  add_custom_command(
+    TARGET tools
+    POST_BUILD
+    COMMAND cp ${CMAKE_SOURCE_DIR}/include/* ${CMAKE_INSTALL_PREFIX}/include/c++/v1/ EXTRA_ARGS=${EXTRA_CLANG_12_FLAGS}
+    COMMENT "Copying libclcxx include files into build include dir"
+    )
+  add_custom_target(
+    test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${CMAKE_INSTALL_PREFIX}/include/c++/v1/
+    )
+  add_custom_target(
+    clean_test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
+    )
+  add_custom_target(
+    remove_libclcxx
+    command cd ${LIBCXX_PATH}/include/c++/v1/ && rm opencl_*
+    )
+endif()
+
+# Clang and libcxx path given build; uses provided clang and libcxx installation paths to compile tests
+if (NOT LIBCXX_PATH STREQUAL "" AND NOT CLANG_PATH STREQUAL "")
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
+    message(FATAL_ERROR "Libclcxx does not support clang versions older than clang-12")
+  endif()
+  set(CUSTOM_COMMAND_USED ON)
+  message(STATUS "Using path to clang provided")
+  message(STATUS "Using path to libcxx provided")
+  message(STATUS "Configuring tests")
+  if (CMAKE_CXX_COMPILER_VERSION EQUAL 12)
+    set(EXTRA_CLANG_12_FLAGS "-x cl -Xclang -finclude-default-header -Xclang -fdeclare-opencl-builtins -cl-std=clc++")
+  endif()
+  add_custom_target(
+    tools
+    )
+  add_custom_command(
+    TARGET tools
+    POST_BUILD
+    COMMAND cp ${CMAKE_SOURCE_DIR}/include/* ${LIBCXX_PATH}/include/c++/v1/
+    COMMENT "Copying libclcxx include files into build include dir"
+    )
+  add_custom_target(
+    test
+    COMMAND cd ${CMAKE_SOURCE_DIR}/test/ && make PATH_TO_LIBCXX_INCLUDE=${LIBCXX_PATH}/include/c++/v1/ CLANG_PATH=${CLANG_PATH} EXTRA_ARGS=${EXTRA_CLANG_12_FLAGS}
     )
   add_custom_target(
     clean_test
@@ -180,4 +249,5 @@ if (NOT CUSTOM_COMMAND_USED)
     COMMAND cd ${CMAKE_SOURCE_DIR}/test && make clean
     )
 endif()
+
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ the [llvm-project](https://github.com/llvm/llvm-project).
 
 	* ``git clone https://github.com/KhronosGroup/libclcxx.git``
 
-2. Configure and build Libclcxx and **all** its dependencies:
+2. Configure and build Libclcxx and its dependencies:
 
 	* ``cd libclcxx``
 
@@ -31,11 +31,13 @@ the [llvm-project](https://github.com/llvm/llvm-project).
 
 		Config options include:
 
-		* Ommiting the build options will build the default target which includes clang and libcxx.
+		* Ommiting the config options will build the default target which includes clang and libcxx.
 		* ``-DDEFAULT_CLANG=ON`` --- Uses system installation of clang to build libcxx and compile tests. Note that this option only works if the environment variable for clang is ``clang`` and not ``clang-12`` or ``clang-13``, use ``-DCLANG_PATH=<path to clang executable>`` in those cases.
 		* ``-DCLANG_PATH=<path to clang executable>`` --- Uses provided executable of clang to build libcxx and compile tests.
 		* ``-DDEFAULT_LIBCXX=ON`` --- Uses system installation of libcxx to build clang and compile tests. Note that libcxx needs to be installed in the ``CMAKE_INSTALL_PREFIX`` directory for this option to work, otherwise use ``-DPATH_TO_LIBCXX=<path to libcxx>``.
-		* ``-DPATH_TO_LIBCXX=<path to libcxx>`` --- Uses the provided libcxx installation to build clang and compile tests. Note that the path needs to be to directory which has the ``include/c++/v1/`` directory within it.
+		* ``-DLIBCXX_PATH=<path to libcxx>`` --- Uses the provided libcxx installation to build clang and compile tests. Note that the path needs to be to directory which has the ``include/c++/v1/`` directory within it.
+		If both ``-DCLANG_PATH`` and ``-DLIBCXX_PATH`` are provided, the provided clang and libcxx installations are used to compile the tests only.
+		If both ``-DDEFAULT_CLANG`` and ``-DDEFAULT_LIBCXX`` are provided, the default clang and libcxx installations are used to compile the tests only.
 
 		Some common build options include:
 
@@ -44,3 +46,5 @@ the [llvm-project](https://github.com/llvm/llvm-project).
 	* ``<generator> tools``
 
 	* ``<generator> test``
+
+		To clean the test object files, you can run ``<generator> clean_test``, this will delete the compiled object files from test/.

--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ This repository makes use of functionality from the [llvm-project](https://githu
 
 		To clean the copied ``opencl_<>`` libclcxx source files from your system libcxx installation (if relevant), you can run ``<generator> clean_libclcxx``.
 
-		To clean everything, including build files, compiled test objects and (if relevant) copied libclcxx source files, you can run ``<generator> clean_all``. **Warning, this will clean your build directory!**
+		To clean everything, including build files, compiled test objects and (if relevant) copied libclcxx source files, you can run ``<generator> clean``. **Warning, this will clean your build directory!**

--- a/README.md
+++ b/README.md
@@ -33,11 +33,10 @@ the [llvm-project](https://github.com/llvm/llvm-project).
 		* ``-DDEFAULT_CLANG=ON`` --- Uses system installation of clang to build libcxx and compile tests. Note that this option only works if the environment variable for clang is ``clang`` and not ``clang-12`` or ``clang-13``, use ``-DCLANG_PATH=<path to clang executable>`` in those cases.
 		* ``-DCLANG_PATH=<path to clang executable>`` --- Uses provided executable of clang to build libcxx and compile tests.
 		* ``-DDEFAULT_LIBCXX=ON`` --- Uses system installation of libcxx to build clang and compile tests. Note that libcxx needs to be installed in the ``CMAKE_INSTALL_PREFIX`` directory for this option to work, otherwise use ``-DPATH_TO_LIBCXX=<path to libcxx>``. **Please note that you may need to use ``sudo`` when building ``tools`` for this option to work.**
-		* ``-DLIBCXX_PATH=<path to libcxx>`` --- Uses the provided libcxx installation to build clang and compile tests. Note that the path needs to be to directory which has the ``include/c++/v1/`` directory within it. **Please omit the trailing '/'**.
+		* ``-DLIBCXX_PATH=<path to libcxx>`` --- Uses the provided libcxx installation to build clang and compile tests. Note that the path needs to be to directory which has the ``include/c++/v1/`` directory within it. **Please omit the trailing '/' in the libcxx path.**.
 		* If both ``-DCLANG_PATH`` and ``-DLIBCXX_PATH`` are provided, the provided clang and libcxx installations are used to compile the tests only.
 		* If both ``-DDEFAULT_CLANG`` and ``-DDEFAULT_LIBCXX`` are provided, the default clang and libcxx installations are used to compile the tests only.
 		* If either ``-DCLANG_PATH`` and ``-DDEFAULT_LIBCXX`` or ``-DLIBCXX_PATH`` and ``-DDEFAULT_CLANG`` combinations are used then the relevant installations are used.
-		* Any other config option or combination which is not stated above will result in the configuration of the ``default`` target.
 
 		Some common build options include:
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ This repository makes use of functionality from the [llvm-project](https://githu
 
 		* ``-DLLVM_PARALLEL_LINK_JOBS=<number of link jobs>`` --- Specify the number of link jobs manually. This is useful when running into memory issues during the linking process of the LLVM executables.
 
+		* ``-DLLVM_TARGETS_TO_BUILD="<target architecture>"`` --- Specifies which targets are enabled. If ommited, the default target is set to ``X86``.
+
 	* ``<generator> tools``
 
 	* ``<generator> test``

--- a/README.md
+++ b/README.md
@@ -5,12 +5,11 @@ SPDX-License-Identifier: Apache-2.0
  
 This repository is now to contain WIP libraries for C++ for OpenCL Kernel Language published in releases of [OpenCL-Docs](https://github.com/KhronosGroup/OpenCL-Docs/releases/tag/cxxforopencl-v1.0-r2).
 
-Other components include:
-the [llvm-project](https://github.com/llvm/llvm-project).
+This repository makes use of functionality from the [llvm-project](https://github.com/llvm/llvm-project) i.e. clang and libcxx.
 
 ### Getting the source code and building Libclcxx
 
-1. Clone Libclcxx:
+1. Clone libclcxx:
 
 	* ``git clone https://github.com/KhronosGroup/libclcxx.git``
 
@@ -33,7 +32,7 @@ the [llvm-project](https://github.com/llvm/llvm-project).
 		* ``-DDEFAULT_CLANG=ON`` --- Uses system installation of clang to build libcxx and compile tests. Note that this option only works if the environment variable for clang is ``clang`` and not ``clang-12`` or ``clang-13``, use ``-DCLANG_PATH=<path to clang executable>`` in those cases.
 		* ``-DCLANG_PATH=<path to clang executable>`` --- Uses provided executable of clang to build libcxx and compile tests.
 		* ``-DDEFAULT_LIBCXX=ON`` --- Uses system installation of libcxx to build clang and compile tests. Note that libcxx needs to be installed in the ``CMAKE_INSTALL_PREFIX`` directory for this option to work, otherwise use ``-DPATH_TO_LIBCXX=<path to libcxx>``. **Please note that you may need to use ``sudo`` when building ``tools`` for this option to work.**
-		* ``-DLIBCXX_PATH=<path to libcxx>`` --- Uses the provided libcxx installation to build clang and compile tests. Note that the path needs to be to directory which has the ``include/c++/v1/`` directory within it. **Please omit the trailing '/' in the libcxx path.**.
+		* ``-DLIBCXX_PATH=<path to libcxx>`` --- Uses the provided libcxx installation to build clang and compile tests. Note that the path needs to be to directory which has the ``include/c++/v1/`` directory within it. **Please omit the trailing '/' in the libcxx path.**
 		* If both ``-DCLANG_PATH`` and ``-DLIBCXX_PATH`` are provided, the provided clang and libcxx installations are used to compile the tests only.
 		* If both ``-DDEFAULT_CLANG`` and ``-DDEFAULT_LIBCXX`` are provided, the default clang and libcxx installations are used to compile the tests only.
 		* If either ``-DCLANG_PATH`` and ``-DDEFAULT_LIBCXX`` or ``-DLIBCXX_PATH`` and ``-DDEFAULT_CLANG`` combinations are used then the relevant installations are used.
@@ -46,4 +45,8 @@ the [llvm-project](https://github.com/llvm/llvm-project).
 
 	* ``<generator> test``
 
-		To clean the test object files, you can run ``<generator> clean_test``, this will delete the compiled object files from test/.
+		To clean the test object files, you can run ``<generator> clean_test``, this will delete the compiled object files from the test source directory.
+
+		To clean the copied ``opencl_<>`` libclcxx source files from your system libcxx installation (if relevant), you can run ``<generator> clean_libclcxx``.
+
+		To clean everything, including build files, compiled test objects and (if relevant) copied libclcxx source files, you can run ``<generator> clean_all``. **Warning, this will clean your build directory!**

--- a/README.md
+++ b/README.md
@@ -4,3 +4,43 @@ SPDX-License-Identifier: Apache-2.0
 -->
  
 This repository is now to contain WIP libraries for C++ for OpenCL Kernel Language published in releases of [OpenCL-Docs](https://github.com/KhronosGroup/OpenCL-Docs/releases/tag/cxxforopencl-v1.0-r2).
+
+Other components include:
+the [llvm-project](https://github.com/llvm/llvm-project).
+
+### Getting the source code and building Libclcxx
+
+1. Clone Libclcxx:
+
+	* ``git clone https://github.com/KhronosGroup/libclcxx.git``
+
+2. Configure and build Libclcxx and **all** its dependencies:
+
+	* ``cd libclcxx``
+
+	* ``mkdir build && cd build``
+
+	* ``cmake -G <generator> [config options] [build options] ..``
+
+		Common build system generators include:
+
+		* ``Ninja``
+		* ``Unix Makefiles``
+		* ``Visual Studio``
+		* ``Xcode``
+
+		Config options include:
+
+		* Ommiting the build options will build the default target which includes clang and libcxx.
+		* ``-DDEFAULT_CLANG=ON`` --- Uses system installation of clang to build libcxx and compile tests. Note that this option only works if the environment variable for clang is ``clang`` and not ``clang-12`` or ``clang-13``, use ``-DCLANG_PATH=<path to clang executable>`` in those cases.
+		* ``-DCLANG_PATH=<path to clang executable>`` --- Uses provided executable of clang to build libcxx and compile tests.
+		* ``-DDEFAULT_LIBCXX=ON`` --- Uses system installation of libcxx to build clang and compile tests. Note that libcxx needs to be installed in the ``CMAKE_INSTALL_PREFIX`` directory for this option to work, otherwise use ``-DPATH_TO_LIBCXX=<path to libcxx>``.
+		* ``-DPATH_TO_LIBCXX=<path to libcxx>`` --- Uses the provided libcxx installation to build clang and compile tests. Note that the path needs to be to directory which has the ``include/c++/v1/`` directory within it.
+
+		Some common build options include:
+
+		* ``-DLLVM_PARALLEL_LINK_JOBS=<number of link jobs>`` --- Specify the number of link jobs manually. This is useful when running into memory issues during the linking process of the LLVM executables.
+
+	* ``<generator> tools``
+
+	* ``<generator> test``

--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@ the [llvm-project](https://github.com/llvm/llvm-project).
 
 		Common build system generators include:
 
-		* ``Ninja``
+		* ``Ninja`` --- **recommended**.
 		* ``Unix Makefiles``
-		* ``Visual Studio``
-		* ``Xcode``
 
 		Config options include:
 
-		* Ommiting the config options will build the default target which includes clang and libcxx.
+		* Ommiting the config options will build the ``default`` target which includes clang and libcxx.
 		* ``-DDEFAULT_CLANG=ON`` --- Uses system installation of clang to build libcxx and compile tests. Note that this option only works if the environment variable for clang is ``clang`` and not ``clang-12`` or ``clang-13``, use ``-DCLANG_PATH=<path to clang executable>`` in those cases.
 		* ``-DCLANG_PATH=<path to clang executable>`` --- Uses provided executable of clang to build libcxx and compile tests.
-		* ``-DDEFAULT_LIBCXX=ON`` --- Uses system installation of libcxx to build clang and compile tests. Note that libcxx needs to be installed in the ``CMAKE_INSTALL_PREFIX`` directory for this option to work, otherwise use ``-DPATH_TO_LIBCXX=<path to libcxx>``.
-		* ``-DLIBCXX_PATH=<path to libcxx>`` --- Uses the provided libcxx installation to build clang and compile tests. Note that the path needs to be to directory which has the ``include/c++/v1/`` directory within it.
-		If both ``-DCLANG_PATH`` and ``-DLIBCXX_PATH`` are provided, the provided clang and libcxx installations are used to compile the tests only.
-		If both ``-DDEFAULT_CLANG`` and ``-DDEFAULT_LIBCXX`` are provided, the default clang and libcxx installations are used to compile the tests only.
+		* ``-DDEFAULT_LIBCXX=ON`` --- Uses system installation of libcxx to build clang and compile tests. Note that libcxx needs to be installed in the ``CMAKE_INSTALL_PREFIX`` directory for this option to work, otherwise use ``-DPATH_TO_LIBCXX=<path to libcxx>``. **Please note that you may need to use ``sudo`` when building ``tools`` for this option to work.**
+		* ``-DLIBCXX_PATH=<path to libcxx>`` --- Uses the provided libcxx installation to build clang and compile tests. Note that the path needs to be to directory which has the ``include/c++/v1/`` directory within it. **Please omit the trailing '/'**.
+		* If both ``-DCLANG_PATH`` and ``-DLIBCXX_PATH`` are provided, the provided clang and libcxx installations are used to compile the tests only.
+		* If both ``-DDEFAULT_CLANG`` and ``-DDEFAULT_LIBCXX`` are provided, the default clang and libcxx installations are used to compile the tests only.
+		* If either ``-DCLANG_PATH`` and ``-DDEFAULT_LIBCXX`` or ``-DLIBCXX_PATH`` and ``-DDEFAULT_CLANG`` combinations are used then the relevant installations are used.
+		* Any other config option or combination which is not stated above will result in the configuration of the ``default`` target.
 
 		Some common build options include:
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This repository is now to contain WIP libraries for C++ for OpenCL Kernel Langua
 
 This repository makes use of functionality from the [llvm-project](https://github.com/llvm/llvm-project) i.e. clang and libcxx.
 
-### Getting the source code and building Libclcxx
+### Getting the source code and building libclcxx
 
 1. Clone libclcxx:
 
 	* ``git clone https://github.com/KhronosGroup/libclcxx.git``
 
-2. Configure and build Libclcxx and its dependencies:
+2. Configure and build libclcxx and its dependencies:
 
 	* ``cd libclcxx``
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,10 +1,11 @@
-# To run: make PATH_TO_LLVM_BUILD=<Path to llvm build folder>
-libclcxx_include = -I../include/
-build_include = -I${PATH_TO_LLVM_BUILD}/include/c++/v1/
+# To run: make PATH_TO_LIBCXX_INCLUDE=<Path to libc++ library>
+# If needed, to pass extra flags use: EXTRA_ARGS=<other flags>
+CLANG_PATH ?= clang
+libcxx_include = -I${PATH_TO_LIBCXX_INCLUDE}
 test-all: *.bc
 
 *.bc: *.clcpp
-	clang ${libclcxx_include} ${build_include} -c *.clcpp --target=spir -emit-llvm
+	${CLANG_PATH} ${EXTRA_ARGS} ${libcxx_include} -c *.clcpp --target=spir -emit-llvm
 
 clean:
 	rm *.bc


### PR DESCRIPTION
- Add CMakeLists.txt file with options to build clang or libcxx or both
- Use newly built clang or libcxx or both to compile libclcxx tests