### PR TITLE
Remove whole file clang guard and only add to test causing bug in clang-12

### DIFF
--- a/test/half_type_traits.clcpp
+++ b/test/half_type_traits.clcpp
@@ -1,11 +1,3 @@
-// Clang-12 cannot compile this test due to a bug which has been addressed in clang-13
-// The bug has to do with the is_convertible type trait as it compiles with it commented out
-#if defined(__clang_major__) && (__clang_major__ < 13)
-#error "Unsupported clang version - use clang-13 or later versions"
-#endif /* if defined __clang_major__ */
-
-#if defined(__clang_major__) && (__clang_major__ > 12)
-
 #include <opencl_type_traits>
 
 void test_float_traits() {
@@ -57,8 +49,12 @@ void test_float_traits() {
   static_assert(std::alignment_of<half>::value == 0.5*std::alignment_of<float>::value);
   static_assert(std::is_convertible<half, float>::value);
   static_assert(std::is_convertible<float, half>::value);
+
+#if defined(__clang_major__) && (__clang_major__ > 12)
+// Clang-12 cannot compile this test due to a bug which has been addressed in clang-13
   static_assert(!std::is_convertible<half, int>::value);
+#endif /* if defined __clang_major__ */
+
   static_assert(std::is_convertible<int, half>::value);
 }
 
-#endif /* if defined __clang_major__ */

--- a/test/half_type_traits.clcpp
+++ b/test/half_type_traits.clcpp
@@ -1,10 +1,10 @@
 // Clang-12 cannot compile this test due to a bug which has been addressed in clang-13
 // The bug has to do with the is_convertible type trait as it compiles with it commented out
-#if defined(__clang_major__) && (__clang_major__ < 12)
+#if defined(__clang_major__) && (__clang_major__ < 13)
 #error "Unsupported clang version - use clang-13 or later versions"
 #endif /* if defined __clang_major__ */
 
-#if defined(__clang_major__) && (__clang_major__ > 11)
+#if defined(__clang_major__) && (__clang_major__ > 12)
 
 #include <opencl_type_traits>
 


### PR DESCRIPTION
`is_convertible<half, int>` was causing a bug in clang-12 so a clang version guard was added.