### PR TITLE
Adding `_t` and `_v` in vector traits

### DIFF
--- a/include/opencl_type_traits
+++ b/include/opencl_type_traits
@@ -452,6 +452,9 @@ template <> struct is_vector_type<double4> : public true_type {};
 template <> struct is_vector_type<double8> : public true_type {};
 template <> struct is_vector_type<double16> : public true_type {};
 
+template<typename T>
+inline constexpr bool is_vector_type_v = is_vector_type<T>::value;
+
 // vector_size
 
 /**
@@ -549,6 +552,9 @@ struct vector_size<double8> : public integral_constant<size_t, 8> {};
 template <>
 struct vector_size<double16> : public integral_constant<size_t, 16> {};
 
+template<class T>
+inline constexpr size_t vector_size_v = vector_size<T>::value;
+
 // scalar_type
 
 /**
@@ -626,6 +632,9 @@ template <> struct scalar_type<double3> { using type = double; };
 template <> struct scalar_type<double4> { using type = double; };
 template <> struct scalar_type<double8> { using type = double; };
 template <> struct scalar_type<double16> { using type = double; };
+
+template<class T> 
+using scalar_type_t = typename scalar_type<T>::type;
 
 // vector_n
 
@@ -706,6 +715,9 @@ template <> struct vector_n<double, 3> { using type = double3; };
 template <> struct vector_n<double, 4> { using type = double4; };
 template <> struct vector_n<double, 8> { using type = double8; };
 template <> struct vector_n<double, 16> { using type = double16; };
+
+template<class T, unsigned int N>
+using vector_n_t =  typename vector_n<T,N>::type;
 
 // is_image
 

--- a/test/is_vector_type.clcpp
+++ b/test/is_vector_type.clcpp
@@ -1,0 +1,65 @@
+#include<opencl_type_traits>
+
+void is_vector_type(){
+
+        static_assert(std::is_vector_type_v<int2>);
+        static_assert(std::is_vector_type_v<int3>);
+        static_assert(std::is_vector_type_v<int4>);
+        static_assert(std::is_vector_type_v<int8>);
+        static_assert(std::is_vector_type_v<int16>);
+
+        static_assert(std::is_vector_type_v<uint2>);
+        static_assert(std::is_vector_type_v<uint3>);
+        static_assert(std::is_vector_type_v<uint4>);
+        static_assert(std::is_vector_type_v<uint8>);
+        static_assert(std::is_vector_type_v<uint16>);
+
+        static_assert(std::is_vector_type_v<char2>);
+        static_assert(std::is_vector_type_v<char3>);
+        static_assert(std::is_vector_type_v<char4>);
+        static_assert(std::is_vector_type_v<char8>);
+        static_assert(std::is_vector_type_v<char16>);
+
+        static_assert(std::is_vector_type_v<uchar2>);
+        static_assert(std::is_vector_type_v<uchar3>);
+        static_assert(std::is_vector_type_v<uchar4>);
+        static_assert(std::is_vector_type_v<uchar8>);
+        static_assert(std::is_vector_type_v<uchar16>);
+
+        static_assert(std::is_vector_type_v<short2>);
+        static_assert(std::is_vector_type_v<short3>);
+        static_assert(std::is_vector_type_v<short4>);
+        static_assert(std::is_vector_type_v<short8>);
+        static_assert(std::is_vector_type_v<short16>);
+
+        static_assert(std::is_vector_type_v<ushort2>);
+        static_assert(std::is_vector_type_v<ushort3>);
+        static_assert(std::is_vector_type_v<ushort4>);
+        static_assert(std::is_vector_type_v<ushort8>);
+        static_assert(std::is_vector_type_v<ushort16>);
+
+        static_assert(std::is_vector_type_v<long2>);
+        static_assert(std::is_vector_type_v<long3>);
+        static_assert(std::is_vector_type_v<long4>);
+        static_assert(std::is_vector_type_v<long8>);
+        static_assert(std::is_vector_type_v<long16>);
+
+        static_assert(std::is_vector_type_v<ulong2>);
+        static_assert(std::is_vector_type_v<ulong3>);
+        static_assert(std::is_vector_type_v<ulong4>);
+        static_assert(std::is_vector_type_v<ulong8>);
+        static_assert(std::is_vector_type_v<ulong16>);
+	
+	static_assert(std::is_vector_type_v<float2>);
+        static_assert(std::is_vector_type_v<float3>);
+        static_assert(std::is_vector_type_v<float4>);
+        static_assert(std::is_vector_type_v<float8>);
+        static_assert(std::is_vector_type_v<float16>);
+
+        static_assert(std::is_vector_type_v<double2>);
+        static_assert(std::is_vector_type_v<double3>);
+        static_assert(std::is_vector_type_v<double4>);
+        static_assert(std::is_vector_type_v<double8>);
+        static_assert(std::is_vector_type_v<double16>);
+}
+

--- a/test/scalar_type.clcpp
+++ b/test/scalar_type.clcpp
@@ -1,0 +1,66 @@
+#include<opencl_type_traits>
+
+void test_scalar_type(){
+
+        static_assert(std::is_same<int,std::scalar_type_t<int2>>::value);
+        static_assert(std::is_same<int,std::scalar_type_t<int3>>::value);
+        static_assert(std::is_same<int,std::scalar_type_t<int4>>::value);
+        static_assert(std::is_same<int,std::scalar_type_t<int8>>::value);
+        static_assert(std::is_same<int,std::scalar_type_t<int16>>::value);
+
+        static_assert(std::is_same<uint,std::scalar_type_t<uint2>>::value);
+        static_assert(std::is_same<uint,std::scalar_type_t<uint3>>::value);
+        static_assert(std::is_same<uint,std::scalar_type_t<uint4>>::value);
+        static_assert(std::is_same<uint,std::scalar_type_t<uint8>>::value);
+        static_assert(std::is_same<uint,std::scalar_type_t<uint16>>::value);
+
+        static_assert(std::is_same<char,std::scalar_type_t<char2>>::value);
+        static_assert(std::is_same<char,std::scalar_type_t<char3>>::value);
+        static_assert(std::is_same<char,std::scalar_type_t<char4>>::value);
+        static_assert(std::is_same<char,std::scalar_type_t<char8>>::value);
+        static_assert(std::is_same<char,std::scalar_type_t<char16>>::value);
+
+        static_assert(std::is_same<uchar,std::scalar_type_t<uchar2>>::value);
+        static_assert(std::is_same<uchar,std::scalar_type_t<uchar3>>::value);
+        static_assert(std::is_same<uchar,std::scalar_type_t<uchar4>>::value);
+        static_assert(std::is_same<uchar,std::scalar_type_t<uchar8>>::value);
+        static_assert(std::is_same<uchar,std::scalar_type_t<uchar16>>::value);
+
+        static_assert(std::is_same<short,std::scalar_type_t<short2>>::value);
+        static_assert(std::is_same<short,std::scalar_type_t<short3>>::value);
+        static_assert(std::is_same<short,std::scalar_type_t<short4>>::value);
+        static_assert(std::is_same<short,std::scalar_type_t<short8>>::value);
+        static_assert(std::is_same<short,std::scalar_type_t<short16>>::value);
+
+        static_assert(std::is_same<ushort,std::scalar_type_t<ushort2>>::value);
+        static_assert(std::is_same<ushort,std::scalar_type_t<ushort3>>::value);
+        static_assert(std::is_same<ushort,std::scalar_type_t<ushort4>>::value);
+        static_assert(std::is_same<ushort,std::scalar_type_t<ushort8>>::value);
+        static_assert(std::is_same<ushort,std::scalar_type_t<ushort16>>::value);
+
+        static_assert(std::is_same<long,std::scalar_type_t<long2>>::value);
+        static_assert(std::is_same<long,std::scalar_type_t<long3>>::value);
+        static_assert(std::is_same<long,std::scalar_type_t<long4>>::value);
+        static_assert(std::is_same<long,std::scalar_type_t<long8>>::value);
+        static_assert(std::is_same<long,std::scalar_type_t<long16>>::value);
+
+        static_assert(std::is_same<ulong,std::scalar_type_t<ulong2>>::value);
+        static_assert(std::is_same<ulong,std::scalar_type_t<ulong3>>::value);
+        static_assert(std::is_same<ulong,std::scalar_type_t<ulong4>>::value);
+        static_assert(std::is_same<ulong,std::scalar_type_t<ulong8>>::value);
+        static_assert(std::is_same<ulong,std::scalar_type_t<ulong16>>::value);
+
+        static_assert(std::is_same<float,std::scalar_type_t<float2>>::value);
+        static_assert(std::is_same<float,std::scalar_type_t<float3>>::value);
+        static_assert(std::is_same<float,std::scalar_type_t<float4>>::value);
+        static_assert(std::is_same<float,std::scalar_type_t<float8>>::value);
+        static_assert(std::is_same<float,std::scalar_type_t<float16>>::value);
+
+        static_assert(std::is_same<double,std::scalar_type_t<double2>>::value);
+        static_assert(std::is_same<double,std::scalar_type_t<double3>>::value);
+        static_assert(std::is_same<double,std::scalar_type_t<double4>>::value);
+        static_assert(std::is_same<double,std::scalar_type_t<double8>>::value);
+        static_assert(std::is_same<double,std::scalar_type_t<double16>>::value);
+
+}
+

--- a/test/vector_n.clcpp
+++ b/test/vector_n.clcpp
@@ -1,0 +1,64 @@
+#include<opencl_type_traits>
+
+void vector_n(){
+
+        static_assert(std::is_same_v<int2,std::vector_n_t<int,2>>);
+        static_assert(std::is_same_v<int3,std::vector_n_t<int,3>>);
+        static_assert(std::is_same_v<int4,std::vector_n_t<int,4>>);
+        static_assert(std::is_same_v<int8,std::vector_n_t<int,8>>);
+        static_assert(std::is_same_v<int16,std::vector_n_t<int,16>>);
+
+        static_assert(std::is_same_v<uint2,std::vector_n_t<uint,2>>);
+        static_assert(std::is_same_v<uint3,std::vector_n_t<uint,3>>);
+        static_assert(std::is_same_v<uint4,std::vector_n_t<uint,4>>);
+        static_assert(std::is_same_v<uint8,std::vector_n_t<uint,8>>);
+        static_assert(std::is_same_v<uint16,std::vector_n_t<uint,16>>);
+
+        static_assert(std::is_same_v<char2,std::vector_n_t<char,2>>);
+        static_assert(std::is_same_v<char3,std::vector_n_t<char,3>>);
+        static_assert(std::is_same_v<char4,std::vector_n_t<char,4>>);
+        static_assert(std::is_same_v<char8,std::vector_n_t<char,8>>);
+        static_assert(std::is_same_v<char16,std::vector_n_t<char,16>>);
+
+        static_assert(std::is_same_v<uchar2,std::vector_n_t<uchar,2>>);
+        static_assert(std::is_same_v<uchar3,std::vector_n_t<uchar,3>>);
+        static_assert(std::is_same_v<uchar4,std::vector_n_t<uchar,4>>);
+        static_assert(std::is_same_v<uchar8,std::vector_n_t<uchar,8>>);
+        static_assert(std::is_same_v<uchar16,std::vector_n_t<uchar,16>>);
+
+        static_assert(std::is_same_v<short2,std::vector_n_t<short,2>>);
+        static_assert(std::is_same_v<short3,std::vector_n_t<short,3>>);
+        static_assert(std::is_same_v<short4,std::vector_n_t<short,4>>);
+        static_assert(std::is_same_v<short8,std::vector_n_t<short,8>>);
+        static_assert(std::is_same_v<short16,std::vector_n_t<short,16>>);
+
+        static_assert(std::is_same_v<ushort2,std::vector_n_t<ushort,2>>);
+        static_assert(std::is_same_v<ushort3,std::vector_n_t<ushort,3>>);
+        static_assert(std::is_same_v<ushort4,std::vector_n_t<ushort,4>>);
+        static_assert(std::is_same_v<ushort8,std::vector_n_t<ushort,8>>);
+        static_assert(std::is_same_v<ushort16,std::vector_n_t<ushort,16>>);
+
+        static_assert(std::is_same_v<long2,std::vector_n_t<long,2>>);
+        static_assert(std::is_same_v<long3,std::vector_n_t<long,3>>);
+        static_assert(std::is_same_v<long4,std::vector_n_t<long,4>>);
+        static_assert(std::is_same_v<long8,std::vector_n_t<long,8>>);
+        static_assert(std::is_same_v<long16,std::vector_n_t<long,16>>);
+
+        static_assert(std::is_same_v<ulong2,std::vector_n_t<ulong,2>>);
+        static_assert(std::is_same_v<ulong3,std::vector_n_t<ulong,3>>);
+        static_assert(std::is_same_v<ulong4,std::vector_n_t<ulong,4>>);
+        static_assert(std::is_same_v<ulong8,std::vector_n_t<ulong,8>>);
+        static_assert(std::is_same_v<ulong16,std::vector_n_t<ulong,16>>);
+
+        static_assert(std::is_same_v<float2,std::vector_n_t<float,2>>);
+        static_assert(std::is_same_v<float3,std::vector_n_t<float,3>>);
+        static_assert(std::is_same_v<float4,std::vector_n_t<float,4>>);
+        static_assert(std::is_same_v<float8,std::vector_n_t<float,8>>);
+        static_assert(std::is_same_v<float16,std::vector_n_t<float,16>>);
+
+        static_assert(std::is_same_v<double2,std::vector_n_t<double,2>>);
+        static_assert(std::is_same_v<double3,std::vector_n_t<double,3>>);
+        static_assert(std::is_same_v<double4,std::vector_n_t<double,4>>);
+        static_assert(std::is_same_v<double8,std::vector_n_t<double,8>>);
+        static_assert(std::is_same_v<double16,std::vector_n_t<double,16>>);
+}

--- a/test/vector_size.clcpp
+++ b/test/vector_size.clcpp
@@ -1,0 +1,65 @@
+#include<opencl_type_traits>
+
+void test_vector_traits(){
+
+	static_assert(std::vector_size_v<int2> == 2);
+        static_assert(std::vector_size_v<int3> == 3);
+        static_assert(std::vector_size_v<int4> == 4);
+        static_assert(std::vector_size_v<int8> == 8);
+        static_assert(std::vector_size_v<int16> == 16);
+
+	static_assert(std::vector_size_v<uint2> == 2);
+        static_assert(std::vector_size_v<uint3> == 3);
+        static_assert(std::vector_size_v<uint4> == 4);
+        static_assert(std::vector_size_v<uint8> == 8);
+        static_assert(std::vector_size_v<uint16> == 16);
+
+	static_assert(std::vector_size_v<char2> == 2);
+        static_assert(std::vector_size_v<char3> == 3);
+        static_assert(std::vector_size_v<char4> == 4);
+        static_assert(std::vector_size_v<char8> == 8);
+        static_assert(std::vector_size_v<char16> == 16);
+
+	static_assert(std::vector_size_v<uchar2> == 2);
+        static_assert(std::vector_size_v<uchar3> == 3);
+        static_assert(std::vector_size_v<uchar4> == 4);
+        static_assert(std::vector_size_v<uchar8> == 8);
+        static_assert(std::vector_size_v<uchar16> == 16);
+
+	static_assert(std::vector_size_v<short2> == 2);
+        static_assert(std::vector_size_v<short3> == 3);
+        static_assert(std::vector_size_v<short4> == 4);
+        static_assert(std::vector_size_v<short8> == 8);
+        static_assert(std::vector_size_v<short16> == 16);
+
+        static_assert(std::vector_size_v<ushort2> == 2);
+        static_assert(std::vector_size_v<ushort3> == 3);
+        static_assert(std::vector_size_v<ushort4> == 4);
+        static_assert(std::vector_size_v<ushort8> == 8);
+        static_assert(std::vector_size_v<ushort16> == 16);
+
+        static_assert(std::vector_size_v<long2> == 2);
+        static_assert(std::vector_size_v<long3> == 3);
+        static_assert(std::vector_size_v<long4> == 4);
+        static_assert(std::vector_size_v<long8> == 8);
+        static_assert(std::vector_size_v<long16> == 16);        
+
+	static_assert(std::vector_size_v<ulong2> == 2);
+        static_assert(std::vector_size_v<ulong3> == 3);
+        static_assert(std::vector_size_v<ulong4> == 4);
+        static_assert(std::vector_size_v<ulong8> == 8);
+        static_assert(std::vector_size_v<ulong16> == 16);
+
+	static_assert(std::vector_size_v<float2> == 2);
+        static_assert(std::vector_size_v<float3> == 3);
+        static_assert(std::vector_size_v<float4> == 4);
+        static_assert(std::vector_size_v<float8> == 8);
+        static_assert(std::vector_size_v<float16> == 16);
+
+        static_assert(std::vector_size_v<double2> == 2);
+        static_assert(std::vector_size_v<double3> == 3);
+        static_assert(std::vector_size_v<double4> == 4);
+        static_assert(std::vector_size_v<double8> == 8);
+        static_assert(std::vector_size_v<double16> == 16);
+
+}


### PR DESCRIPTION
## Modified `include/opencl_type_traits` file:

### Added `_t` alias for the follwing:
- `vector_n`
- `scalar_type`

### Added `_v` alias for:
- `vector_size`
- `is_vector_type`

## Added new files in the `test/` directory with unit tests for each of the aforementioned modifications:

- `is_vector_type.clcpp` for `is_vector_type`
- `vector_size.clcpp` for `vector_size`
- `scalar_type.clcpp` for `scalar_type`
- `vector_n.clcpp` for `vector_n`